### PR TITLE
Add support for group DMs

### DIFF
--- a/Constants.js
+++ b/Constants.js
@@ -18,7 +18,7 @@ module.exports = ({
     }
   },
   InjectionIDs: {
-    ContextMenu: [ 'bf-DMUserContextMenu', 'bf-GroupDMUserContextMenu', 'bf-GuildChannelUserContextMenu' ],
+    ContextMenu: [ 'bf-DMUserContextMenu', 'bf-GroupDMContextMenu', 'bf-GroupDMUserContextMenu', 'bf-GuildChannelUserContextMenu' ],
     DisplayStar: [ 'bf-star-member', 'bf-star-message' ],
     FavoriteFriendChannel: [ 'bf-direct-messages', 'bf-direct-messages-channel', 'bf-direct-messages-mount' ],
     FavoriteFriendsSection: [ 'bf-favorite-friends-tabbar' ],

--- a/Settings.jsx
+++ b/Settings.jsx
@@ -3,6 +3,16 @@ const { getModule, getModuleByDisplayName } = require('powercord/webpack');
 const { SwitchItem, TextInput } = require('powercord/components/settings');
 const { Sounds } = require('./Constants');
 
+const GROUP_DM_ICONS = [
+  'https://discord.com/assets/861ab526aa1fabb04c6b7da8074e3e21.png', // orange
+  'https://discord.com/assets/b8912961ea6ab32f0655d583bbc26b4f.png', // yellow
+  'https://discord.com/assets/773616c3c8a7e21f8a774eb0d5625436.png', // teal
+  'https://discord.com/assets/f810dc5fedb7175c43a3389aa890534f.png', // green
+  'https://discord.com/assets/e1fb24a120bdd003a84e021b16ec3bef.png', // blue
+  'https://discord.com/assets/b3150d5cef84b9e82128a1131684f287.png', // purple
+  'https://discord.com/assets/485a854d5171c8dc98088041626e6fea.png', // pink
+  'https://discord.com/assets/1531b79c2f2927945582023e1edaaa11.png', // red
+];
 
 module.exports = class Settings extends React.Component {
   constructor (props) {
@@ -14,6 +24,7 @@ module.exports = class Settings extends React.Component {
     this.state = {
       friendsQuery: '',
       favfriends: get('favfriends', []),
+      favdms: get('favdms', []),
       notifsounds: get('notifsounds', {}),
       infomodal: get('infomodal', true),
       displaystar: get('displaystar', true),
@@ -29,7 +40,8 @@ module.exports = class Settings extends React.Component {
       PopoutList: await getModuleByDisplayName('PopoutList'),
       playSound: (await getModule([ 'playSound' ])).playSound,
       getUser: (await getModule([ 'getUser', 'getUsers' ])).getUser,
-      getRelationships: (await getModule([ 'getRelationships' ])).getRelationships
+      getRelationships: (await getModule([ 'getRelationships' ])).getRelationships,
+      getMutablePrivateChannels: (await getModule([ 'getChannel' ])).getMutablePrivateChannels,
     });
   }
 
@@ -37,47 +49,95 @@ module.exports = class Settings extends React.Component {
     if (!this.state.VerticalScroller) {
       return null;
     }
-    const { VerticalScroller, Flex, Text, PopoutList, playSound, getUser, getRelationships } = this.state;
+    const { VerticalScroller, Flex, Text, PopoutList, playSound, getUser, getRelationships, getMutablePrivateChannels } = this.state;
     const PopoutListSearchBar = PopoutList.prototype.constructor.SearchBar;
     const PopoutListDivider = PopoutList.prototype.constructor.Divider;
     const FlexChild = Flex.prototype.constructor.Child;
     const SelectableItem = PopoutList.prototype.constructor.Item;
 
     const relationships = getRelationships();
-    const friends = Object.keys(relationships).filter(relation => relationships[relation] === 1);
+    const friends = Object.keys(relationships)
+      .filter(relation => relationships[relation] === 1)
+      .map(getUser)
+      .map((user) => ({
+        id: user.id,
+        name: user.username,
+        subtext: `#${user.discriminator}`,
+        icon: !user.avatar
+          ? `https://cdn.discordapp.com/embed/avatars/${
+              user.discriminator % 5
+            }.png`
+          : `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`,
+        groupId: 'favfriends',
+      }));
+
+    const dms = Object.values(getMutablePrivateChannels())
+      .filter((x) => x.type === 3)
+      .map((dm) => ({
+        id: dm.id,
+        name: dm.name || dm.rawRecipients.map((x) => x.username).join(', '),
+        subtext: `${dm.recipients.length + 1} Members`,
+        icon: !dm.icon
+          ? GROUP_DM_ICONS[
+              (BigInt(dm.id) >> 22n) % BigInt(GROUP_DM_ICONS.length)
+            ]
+          : `https://cdn.discordapp.com/channel-icons/${dm.id}/${dm.icon}.png`,
+        groupId: 'favdms',
+      }));
+
+    const items = [...friends, ...dms];
+
     return (
       <div>
         <h5 className='h5-18_1nd title-3sZWYQ size12-3R0845 height16-2Lv3qA weightSemiBold-NJexzi marginBottom8-AtZOdT'>
-          Manage favorited friends
+          Manage favorited friends and group DMs
         </h5>
         <div className='description-3_Ncsb formText-3fs7AJ marginBottom20-32qID7 modeDefault-3a2Ph1 primary-jw0I4K'>
-          You can add or remove favorited friends from your friends list here.
+          You can add or remove favorited friends and group DMs from your list
+          here.
         </div>
+
         <PopoutList
           className='bf-user-settings guildSettingsAuditLogsUserFilterPopout-3Jg5NE pc-guildSettingsAuditLogsUserFilterPopout elevationBorderHigh-2WYJ09 pc-elevationBorderHigh'
           popoutKey='bf-users'
         >
           <PopoutListSearchBar
             autoFocus={true}
-            placeholder='Search friends'
+            placeholder='Search friends and group DMs'
             query={this.state.friendsQuery || ''}
             onChange={(e) => this.setState({ friendsQuery: e })}
             onClear={() => this.setState({ friendsQuery: '' })}
           />
-          <PopoutListDivider/>
-          <VerticalScroller
-            className='scroller-2CvAgC pc-scroller'
-          >
-            {friends
-              .map(getUser)
-              .filter(user => this.state.friendsQuery ? user.username.toLowerCase().includes(this.state.friendsQuery.toLowerCase()) : true)
-              .map((user, i) =>
-                <SelectableItem className='bf-friend-item' id={user.id} key={i.toString()} selected={this.state.favfriends.includes(user.id)} onClick={(e) => {
+
+          {this.state.friendsQuery ? (
+            <PopoutListDivider />
+          ) : (
+            <div style={{ paddingTop: '8px' }} />
+          )}
+
+          {this.state.friendsQuery && (
+            <VerticalScroller className='scroller-2CvAgC pc-scroller'>
+              {items
+                .filter(({ name }) =>
+                  this.state.friendsQuery
+                    ? name
+                        .toLowerCase()
+                        .includes(this.state.friendsQuery.toLowerCase())
+                    : true
+                )
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((item, i) => (
+                  <SelectableItem
+                    className='bf-friend-item'
+                    id={item.id}
+                    key={i.toString()}
+                    selected={this.state[item.groupId].includes(item.id)}
+                    onClick={(e) => {
                   if (!e.selected) {
-                    this.state.favfriends.push(e.id);
-                    this._set('favfriends', this.state.favfriends);
+                        this.state[item.groupId].push(e.id);
+                        this._set(item.groupId, this.state[item.groupId]);
                   } else {
-                    this._set('favfriends', this.state.favfriends.filter(a => a !== e.id));
+                        this._set(item.groupId, this.state[item.groupId].filter((a) => a !== e.id));
                   }
                   this.plugin.reload();
                 }}>
@@ -86,7 +146,7 @@ module.exports = class Settings extends React.Component {
                       <Flex align='alignCenter-1dQNNs' basis='auto' grow={1} shrink={1}>
                         <FlexChild key='avatar' basis='auto' grow={0} shrink={0} wrap={false}>
                           <img
-                            src={!user.avatar ? `https://cdn.discordapp.com/embed/avatars/${user.discriminator % 5}.png` : `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`}
+                            src={item.icon}
                             width={32}
                             height={32}
                             style={{ borderRadius: '360px' }}
@@ -94,23 +154,19 @@ module.exports = class Settings extends React.Component {
                         </FlexChild>
                         <FlexChild key='user-text' basis='auto' grow={1} shrink={1} wrap={false}>
                           <div className='userText-1WDPps'>
-                            <span className='userText-1WDPps'>{user.username}</span>
-                            <span className='discriminator-3tYCOD'>#{user.discriminator}</span>
+                              <span className='userText-1WDPps'>{item.name}</span>
+                              {' '}
+                              <span className='discriminator-3tYCOD'>{item.subtext}</span>
                           </div>
                         </FlexChild>
                       </Flex>
                     </div>
                   </Flex>
-                </SelectableItem>)
-              .sort((a, b) => {
-                const firstName = a.props.children.props.children.props.children.props.children[1].props.children.props.children[0].props.children;
-                const secondName = b.props.children.props.children.props.children.props.children[1].props.children.props.children[0].props.children;
-                return firstName.localeCompare(secondName);
-              })
-            }
+                  </SelectableItem>
+                ))}
           </VerticalScroller>
+          )}
         </PopoutList>
-
 
         <SwitchItem
           note='Toggles the functionality of the information button within the DM list on favorited friends'

--- a/components/FavoriteFriends.jsx
+++ b/components/FavoriteFriends.jsx
@@ -13,8 +13,8 @@ module.exports = class FavoriteFriends extends React.PureComponent {
     }
 
     render () {
-        const { classes, FAV_FRIENDS, _this } = this.props;
-        if (!classes || !FAV_FRIENDS || !FAV_FRIENDS.length) return null;
+        const { classes, FAV_FRIENDS, FAV_DMS, _this } = this.props;
+        if (!classes || !FAV_FRIENDS || !FAV_DMS || (!FAV_FRIENDS.length && !FAV_DMS.length)) return null;
         const { lastMessageId } = getModule([ 'lastMessageId' ], false);
         const { getDMFromUserId } = getModule([ 'getDMFromUserId' ], false);
 
@@ -40,9 +40,11 @@ module.exports = class FavoriteFriends extends React.PureComponent {
             </h2>,
             // Friends
             this.state.expanded
-                ? FAV_FRIENDS
-                    .sort((a, b) => lastMessageId(getDMFromUserId(b)) - lastMessageId(getDMFromUserId(a)))
-                    .map(userId => <this.props.ConnectedPrivateChannel userId={userId} currentSelectedChannel={this.props.selectedChannelId} />)
+                ? [...FAV_FRIENDS.map(x => [x, getDMFromUserId(x)]), ...FAV_DMS.map(x => [x, x])]
+                    .sort((a, b) => lastMessageId(b[1]) - lastMessageId(a[1]))
+                    .map(([id, cid]) => (
+                        <this.props.ConnectedPrivateChannel id={id} isDM={id === cid} currentSelectedChannel={this.props.selectedChannelId} />)
+                    )
                 : null
         ];
     }

--- a/index.js
+++ b/index.js
@@ -39,10 +39,9 @@ module.exports = class BetterFriends extends Plugin {
   async start () {
     this.instances = {};
     this.FAV_FRIENDS = this.settings.get('favfriends');
-    this.FAV_DMS = this.settings.get('favdms');
+    this.FAV_DMS = this.settings.get('favdms') || [];
     if (!this.FAV_FRIENDS) {
       this.FAV_FRIENDS = [];
-      this.FAV_DMS = [];
       for (const setting of Object.keys(this.DEFAULT_SETTINGS)) {
         if (this.DEFAULT_SETTINGS[setting] === undefined && !this.FAV_FRIENDS) { /* eslint-disable-line */ /* I know this is bad practice, hopefully I'll find a better solution soon */
           this.settings.set(this.settings.get(setting, this.DEFAULT_SETTINGS[setting]));

--- a/index.js
+++ b/index.js
@@ -39,8 +39,10 @@ module.exports = class BetterFriends extends Plugin {
   async start () {
     this.instances = {};
     this.FAV_FRIENDS = this.settings.get('favfriends');
+    this.FAV_DMS = this.settings.get('favdms');
     if (!this.FAV_FRIENDS) {
       this.FAV_FRIENDS = [];
+      this.FAV_DMS = [];
       for (const setting of Object.keys(this.DEFAULT_SETTINGS)) {
         if (this.DEFAULT_SETTINGS[setting] === undefined && !this.FAV_FRIENDS) { /* eslint-disable-line */ /* I know this is bad practice, hopefully I'll find a better solution soon */
           this.settings.set(this.settings.get(setting, this.DEFAULT_SETTINGS[setting]));

--- a/modules/ContextMenu.js
+++ b/modules/ContextMenu.js
@@ -17,40 +17,51 @@ module.exports = async function () {
     const relationships = getRelationships();
     return Object.keys(relationships).filter(relation => relationships[relation] === 1).includes(id);
   };
-  const isFavoriteFriend = (id) => this.FAV_FRIENDS.includes(id);
+
   for (const module of InjectionIDs.ContextMenu.map(id => id.replace('bf-', ''))) {
     const m = await getModule(m => m.default && m.default.displayName === module);
     inject(`bf-${module}`, m, 'default', (args, res) => {
-      const { id } = args[0].user;
-      if (isFriend(id)) {
-        const group = findInReactTree(res, c => Array.isArray(c) && c.find(item => item && item.props && item.props.id === 'block'));
-        if (!group) return res;
-        if (!isFavoriteFriend(id)) {
-          group.push(
-            React.createElement(MenuItem, {
-              id: 'bf-add',
-              label: 'Add as Favorite',
-              action: () => {
-                this.FAV_FRIENDS.push(id);
-                this.settings.set('favfriends', this.FAV_FRIENDS);
-                this.reload();
-              }
-            })
-          );
-        } else {
-          group.push(
-            React.createElement(MenuItem, {
-              id: 'bf-remove',
-              label: 'Remove from Favorites',
-              action: () => {
-                this.FAV_FRIENDS = this.FAV_FRIENDS.filter(a => a !== id);
-                this.settings.set('favfriends', this.FAV_FRIENDS);
-                this.reload();
-              }
-            })
-          );
-        }
+      let id, getKey, updateKey;
+
+      if (module === 'GroupDMContextMenu') {
+        id = args[0].channel.id;
+        getKey = 'FAV_DMS';
+        updateKey = 'favdms';
+      } else {
+        id = args[0].user.id;
+        if (!isFriend(id)) return res;
+        getKey = 'FAV_FRIENDS';
+        updateKey = 'favfriends';
       }
+
+      const group = findInReactTree(res, c => Array.isArray(c) && c.find(item => item && item.props && ['block', 'remove-icon'].includes(item.props.id)));
+      if (!group) return res;
+      if (!this[getKey].includes(id)) {
+        group.push(
+          React.createElement(MenuItem, {
+            id: 'bf-add',
+            label: 'Add as Favorite',
+            action: () => {
+              this[getKey].push(id);
+              this.settings.set(updateKey, this[getKey]);
+              this.reload();
+            }
+          })
+        );
+      } else {
+        group.push(
+          React.createElement(MenuItem, {
+            id: 'bf-remove',
+            label: 'Remove from Favorites',
+            action: () => {
+              this[getKey] = this[getKey].filter(a => a !== id);
+              this.settings.set(updateKey, this[getKey]);
+              this.reload();
+            }
+          })
+        );
+      }
+      
       return res
     });
     m.default.displayName = module;


### PR DESCRIPTION
Added support for group DMs. Created a new `favdms` setting store separate from the `favfriends` one, so nothing previously should break.

The input box in the setting is combined as shown:

<img width="765" alt="Screen Shot 2021-06-29 at 2 28 35 AM" src="https://user-images.githubusercontent.com/20295134/123773775-be4c8a00-d881-11eb-8432-cff2c4cc21e6.png">

(The group DM is circled.)

Group DMs show up on the sidebar in the same category as previously:

<img width="253" alt="Screen Shot 2021-06-29 at 2 14 26 AM" src="https://user-images.githubusercontent.com/20295134/123771233-bb509a00-d87f-11eb-92ae-2b9ff5184315.png">

There isn't really much else to it. It seems to be a highly wanted feature (Closes #17) and I needed it too.